### PR TITLE
Added passkey and default for config.xml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 gpu: false
 power: light
 user: ansible.spruce.ki
+passkey: 1385yourpasskeyhere5924
 # 257758 is team "spruce.ki"
 team: 257758
 state: present

--- a/templates/config.xml
+++ b/templates/config.xml
@@ -7,6 +7,7 @@
 
   <!-- User Information -->
   <user v='{{ user }}'/>
+  <passkey v='{{ passkey }}'/>
 
   <!-- The team ID -->
   <team v='{{ team }}'/>


### PR DESCRIPTION
Added a passkey entry for config.xml and a corresponding generic default. From my test, it appears to just ignore any invalid passkey and continue on with just the user and team.